### PR TITLE
Update peer dependencies to support react 16, 17 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   "peerDependencies": {
     "@gnosis.pm/safe-react-components": "^0.9.6",
     "@material-ui/core": "4.X.X",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "16.x.x || 17.x.x || 18.x.x",
+    "react-dom": "16.x.x || 17.x.x || 18.x.x"
   },
   "dependencies": {
     "@material-ui/icons": "^4.11.2",


### PR DESCRIPTION
Should be safe according to: https://v4.mui.com/getting-started/installation/

Closes #10 