### PR TITLE
bump version to match github releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodiac-ui-components",
-  "version": "0.0.32",
+  "version": "0.1.3",
   "description": "A shared UI component library for Gnosis Guild's Zodiac.",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",


### PR DESCRIPTION
The release version numbers and the package.json versions weren't matching, this fixes that. This uses `0.1.3` as the version number as that is the next release number.