### PR TITLE
Fix remove storybook from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodiac-ui-components",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A shared UI component library for Gnosis Guild's Zodiac.",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     ],
     "exclude": [
         "node_modules",
-        "lib"
+        "lib",
+        "**/*.stories.tsx"
     ]
   }


### PR DESCRIPTION
Issue reference: https://stackoverflow.com/questions/61519483/extending-an-mui-component-gives-ts-error-about-css-property-missing